### PR TITLE
Inject app. arguments into dispatched functions + exit codes + pep8

### DIFF
--- a/app/arguments.py
+++ b/app/arguments.py
@@ -5,21 +5,21 @@ import sys
 import argparse
 import subprocess
 import colorful
-import variables
-import containers
-import orchestration
+import variables as vars
+import containers as cont
+import orchestration as orch
 
 
 def return_version(args):
     """Returns either the latest commit hash or tagged release"""
     latest_commit = subprocess.getoutput("cd %s && git rev-parse --short HEAD"
-                                         % (variables.APP_ROOT))
-    if 'dev' in variables.APP_VERSION:
-        ver = colorful.orange(latest_commit)
-        print("You are running the dev version at commit " + ver)
+                                         % (vars.APP_ROOT))
+    if 'dev' in vars.APP_VERSION:
+        hash = colorful.orange(latest_commit)
+        print("You are running the dev version at commit " + hash)
     else:
-        ver = colorful.orange(variables.APP_VERSION)
-        print("You are running tagged release " + ver)
+        tag = colorful.orange(vars.APP_VERSION)
+        print("You are running tagged release " + tag)
     return args.exit_ok
 
 
@@ -30,52 +30,52 @@ def get_parser():
                         help="Targets an arbitrary app")
     parser.add_argument('--drupal', dest='mainfunc', action='store_const',
                         help='Spins up a ready-to-use Drupal install',
-                        const=orchestration.app_drupal)
+                        const=orch.app_drupal)
     parser.add_argument('--lightning', dest='mainfunc', action='store_const',
                         help='Spins up a ready-to-use Lightning install',
-                        const=orchestration.app_lightning)
+                        const=orch.app_lightning)
     parser.add_argument('--blt', dest='mainfunc', action='store_const',
                         help='Spins up a ready-to-use BLT build',
-                        const=orchestration.app_blt)
+                        const=orch.app_blt)
     parser.add_argument('--dev', dest='mainfunc', action='store_const',
                         help='Prepare app for development work with no'
                              ' caching and helper modules enabled.',
-                        const=orchestration.app_dev)
+                        const=orch.app_dev)
     parser.add_argument('--prod', dest='mainfunc', action='store_const',
                         help='Opinionated setup with all known performance'
                              ' best practices enabled.',
-                        const=orchestration.app_prod)
+                        const=orch.app_prod)
     parser.add_argument('--import', dest='mainfunc', action='store_const',
                         help="Imports an app from the web container's"
                              " import directory",
-                        const=orchestration.app_import)
+                        const=orch.app_import)
     parser.add_argument('--delete', dest='mainfunc', action='store_const',
                         help='Deletes an arbitrary docroot',
-                        const=orchestration.app_delete)
+                        const=orch.app_delete)
     parser.add_argument('--start', dest='mainfunc', action='store_const',
                         help='Starts all containers',
-                        const=containers.start)
+                        const=cont.start)
     parser.add_argument('--stop', dest='mainfunc', action='store_const',
                         help='Stops all containers',
-                        const=containers.stop)
+                        const=cont.stop)
     parser.add_argument('--restart', dest='mainfunc', action='store_const',
                         help='Restarts all containers',
-                        const=containers.restart)
+                        const=cont.restart)
     parser.add_argument("--health", dest='mainfunc', action='store_const',
                         help="Runs a service healthcheck",
-                        const=containers.health)
+                        const=cont.health)
     parser.add_argument('--php7.2', dest='mainfunc', action='store_const',
                         help='Sets the PHP version to 7.2',
-                        const=containers.set_default_php_version)
+                        const=cont.set_default_php_version)
     parser.add_argument('--php7.1', dest='mainfunc', action='store_const',
                         help='Sets the PHP version to 7.1',
-                        const=containers.set_previous_php_version)
+                        const=cont.set_previous_php_version)
     parser.add_argument('--list', dest='mainfunc', action='store_const',
                         help='Lists all deployed apps',
-                        const=orchestration.app_list)
+                        const=orch.app_list)
     parser.add_argument('--tests', dest='mainfunc', action='store_const',
                         help='Runs the Ansible test suite',
-                        const=orchestration.run_tests)
+                        const=orch.run_tests)
     parser.add_argument('--version', dest='mainfunc', action='store_const',
                         help='Returns the drucker version',
                         const=return_version)

--- a/app/arguments.py
+++ b/app/arguments.py
@@ -1,113 +1,95 @@
 #!/usr/bin/env python3
-"""Allows to pass arguments to the drucker command"""
+"""Parsing of command line arguments passed to the drucker."""
 
-import subprocess as s
+import sys
 import argparse
-import colorful as c
-import variables as v
-import orchestration as o
+import subprocess
+import colorful
+import variables
 import containers
+import orchestration
 
 
-def return_version():
+def return_version(args):
     """Returns either the latest commit hash or tagged release"""
-    latest_commit = s.getoutput("cd %s && git rev-parse --short HEAD" % (v.APP_ROOT))
-
-    if 'dev' in v.APP_VERSION:
-        print("You are running the dev version at commit " + c.orange(latest_commit))
+    latest_commit = subprocess.getoutput("cd %s && git rev-parse --short HEAD"
+                                         % (variables.APP_ROOT))
+    if 'dev' in variables.APP_VERSION:
+        ver = colorful.orange(latest_commit)
+        print("You are running the dev version at commit " + ver)
     else:
-        print("You are running tagged release " + c.orange(v.APP_VERSION))
+        ver = colorful.orange(variables.APP_VERSION)
+        print("You are running tagged release " + ver)
+    return args.exit_ok
 
 
-def run_command():
-    """Parses command-line arguments."""
+def get_parser():
+    """Returns a ArgumentParser object with command-line arguments."""
     parser = argparse.ArgumentParser()
-
     parser.add_argument("app", nargs='?',
                         help="Targets an arbitrary app")
-
-    parser.add_argument('--drupal', dest='drupal', action="store_true",
-                        help='Spins up a ready-to-use Drupal install')
-
-    parser.add_argument('--lightning', dest='lightning', action="store_true",
-                        help='Spins up a ready-to-use Lightning install')
-
-    parser.add_argument('--blt', dest='blt', action="store_true",
-                        help='Spins up a ready-to-use BLT build')
-
-    parser.add_argument('--dev', dest='dev', action="store_true",
-                        help='Prepare app for development work with no caching and helper modules enabled.')
-
-    parser.add_argument('--prod', dest='prod', action="store_true",
-                        help='Opinionated setup with all known performance best practices enabled.')
-
-    parser.add_argument('--import', dest='import_app', action="store_true",
-                        help="Imports an app from the web container's import directory")
-
-    parser.add_argument('--delete', dest='delete', action="store_true",
-                        help='Deletes an arbitrary docroot')
-
-    parser.add_argument('--start', dest='start', action="store_true",
-                        help='Starts all containers')
-
-    parser.add_argument('--stop', dest='stop', action="store_true",
-                        help='Stops all containers')
-
-    parser.add_argument('--restart', dest='restart', action="store_true",
-                        help='Restarts all containers')
-
-    parser.add_argument("--health", dest="health", action="store_true",
-                        help="Runs a service healthcheck")
-
-    parser.add_argument('--php7.2', dest='php72', action="store_true",
-                        help='Sets the PHP version to 7.2')
-
-    parser.add_argument('--php7.1', dest='php71', action="store_true",
-                        help='Sets the PHP version to 7.1')
-
-    parser.add_argument('--list', dest='list', action="store_true",
-                        help='Lists all deployed apps')
-
-    parser.add_argument('--tests', dest='tests', action="store_true",
-                        help='Runs the Ansible test suite')
-
-    parser.add_argument('--version', dest='version', action="store_true",
-                        help='Returns the drucker version')
-
-    args = parser.parse_args()
-
-    if args.health:
-        containers.health()
-    elif args.start:
-        containers.start()
-    elif args.stop:
-        containers.stop()
-    elif args.restart:
-        containers.restart()
-    elif args.php72:
-        containers.set_default_php_version()
-    elif args.php71:
-        containers.set_previous_php_version()
-    elif args.list:
-        o.app_list()
-    elif args.drupal:
-        o.app_drupal(args.app)
-    elif args.lightning:
-        o.app_lightning(args.app)
-    elif args.blt:
-        o.app_blt(args.app)
-    elif args.delete:
-        o.app_delete(args.app)
-    elif args.dev:
-        o.app_dev(args.app)
-    elif args.prod:
-        o.app_prod(args.app)
-    elif args.import_app:
-        o.app_import(args.app)
-    elif args.tests:
-        o.run_tests()
-    elif args.version:
-        return_version()
+    parser.add_argument('--drupal', dest='mainfunc', action='store_const',
+                        help='Spins up a ready-to-use Drupal install',
+                        const=orchestration.app_drupal)
+    parser.add_argument('--lightning', dest='mainfunc', action='store_const',
+                        help='Spins up a ready-to-use Lightning install',
+                        const=orchestration.app_lightning)
+    parser.add_argument('--blt', dest='mainfunc', action='store_const',
+                        help='Spins up a ready-to-use BLT build',
+                        const=orchestration.app_blt)
+    parser.add_argument('--dev', dest='mainfunc', action='store_const',
+                        help='Prepare app for development work with no'
+                             ' caching and helper modules enabled.',
+                        const=orchestration.app_dev)
+    parser.add_argument('--prod', dest='mainfunc', action='store_const',
+                        help='Opinionated setup with all known performance'
+                             ' best practices enabled.',
+                        const=orchestration.app_prod)
+    parser.add_argument('--import', dest='mainfunc', action='store_const',
+                        help="Imports an app from the web container's"
+                             " import directory",
+                        const=orchestration.app_import)
+    parser.add_argument('--delete', dest='mainfunc', action='store_const',
+                        help='Deletes an arbitrary docroot',
+                        const=orchestration.app_delete)
+    parser.add_argument('--start', dest='mainfunc', action='store_const',
+                        help='Starts all containers',
+                        const=containers.start)
+    parser.add_argument('--stop', dest='mainfunc', action='store_const',
+                        help='Stops all containers',
+                        const=containers.stop)
+    parser.add_argument('--restart', dest='mainfunc', action='store_const',
+                        help='Restarts all containers',
+                        const=containers.restart)
+    parser.add_argument("--health", dest='mainfunc', action='store_const',
+                        help="Runs a service healthcheck",
+                        const=containers.health)
+    parser.add_argument('--php7.2', dest='mainfunc', action='store_const',
+                        help='Sets the PHP version to 7.2',
+                        const=containers.set_default_php_version)
+    parser.add_argument('--php7.1', dest='mainfunc', action='store_const',
+                        help='Sets the PHP version to 7.1',
+                        const=containers.set_previous_php_version)
+    parser.add_argument('--list', dest='mainfunc', action='store_const',
+                        help='Lists all deployed apps',
+                        const=orchestration.app_list)
+    parser.add_argument('--tests', dest='mainfunc', action='store_const',
+                        help='Runs the Ansible test suite',
+                        const=orchestration.run_tests)
+    parser.add_argument('--version', dest='mainfunc', action='store_const',
+                        help='Returns the drucker version',
+                        const=return_version)
+    return parser
 
 
-run_command()
+if __name__ == '__main__':
+    PARSER = get_parser()
+    ARGS = PARSER.parse_args()
+    # Define convenience constants for UNIX exit codes so that third-party
+    # developers can use Drucker in scripts:
+    # http://tldp.org/LDP/abs/html/exitcodes.html
+    ARGS.exit_ok = 0
+    ARGS.exit_fail = 1
+    # Dispatch program execution to the chosen option and send args to it.
+    EXITCODE = ARGS.mainfunc(ARGS)
+    sys.exit(EXITCODE)

--- a/app/containers.py
+++ b/app/containers.py
@@ -87,7 +87,8 @@ def set_previous_php_version(args):
 
 def set_default_php_version(args):
     """Set the PHP version to the current stable version"""
-    print(c.blue("Switch to %s..." % (v.DEFAULT_PHP))) # pylint: disable=E1101
+    # pylint: disable=E1101
+    print(c.blue("Switch to %s..." % (v.DEFAULT_PHP)))
     s.run('''ansible-playbook -i %s/orchestration/hosts\
              --user=%s %s/orchestration/commands/default-php.yml\
              --extra-vars "ansible_sudo_pass=%s"

--- a/app/containers.py
+++ b/app/containers.py
@@ -7,16 +7,16 @@ import variables as v
 import services
 
 
-def status():
+def status(args):
     """Make sure all containers are started"""
     if s.getoutput("docker ps --format=\"{{.Names}}\"  | grep -c drucker") != "5":
         print(c.red("You cannot run this command when one or more containers are stopped!"))
-        start()
+        start(args)
 
 
-def health():
+def health(args):
     """Checks that all required services are up and running"""
-    status()
+    status(args)
 
     print(c.blue("Checking services for %s container..." % (v.MIRROR_CONTAINER)))
     services.check(v.MIRROR_CONTAINER, "apache2", "Apache")
@@ -36,9 +36,10 @@ def health():
     print(c.blue("Checking services for %s container..." % (v.WEB_CONTAINER)))
     services.check(v.WEB_CONTAINER, "apache2", "Apache")
     services.phpfpm(v.DB_CONTAINER)
+    return args.exit_ok
 
 
-def start():
+def start(args):
     """Starts all containers"""
     for container in v.CONTAINERS:
         if not s.getoutput('''docker ps --format=\"{{.Names}}\"  | grep %s
@@ -47,10 +48,11 @@ def start():
             s.getoutput("docker start %s" % (container))
         else:
             print("%s container is already started." % (container))
-    health()
+    health(args)
+    return args.exit_ok
 
 
-def stop():
+def stop(args):
     """Stops all containers"""
     for container in v.CONTAINERS:
         if s.getoutput('''docker ps --format=\"{{.Names}}\"  | grep %s
@@ -59,31 +61,35 @@ def stop():
             s.getoutput("docker stop %s" % (container))
         else:
             print("%s container is already stopped." % (container))
+    return args.exit_ok
 
 
-def restart():
+def restart(args):
     """Restarts all containers"""
     for container in v.CONTAINERS:
         if s.getoutput('''docker ps --format=\"{{.Names}}\"  | grep %s
                            ''' % (container)):
             print(c.blue("Restarting %s container..." % (container)))
             s.getoutput("docker restart %s" % (container))
-    health()
+    health(args)
+    return args.exit_ok
 
 
-def set_previous_php_version():
+def set_previous_php_version(args):
     """Sets the PHP version to the previous version"""
     print(c.blue("Switch to %s..." % (v.PREVIOUS_PHP)))
     s.run('''ansible-playbook -i %s/orchestration/hosts\
              --user=%s %s/orchestration/commands/previous-php.yml\
              --extra-vars "ansible_sudo_pass=%s"
           ''' % (v.APP_DIR, v.APP, v.APP_DIR, v.APP), shell=True)
+    return args.exit_ok
 
 
-def set_default_php_version():
+def set_default_php_version(args):
     """Set the PHP version to the current stable version"""
     print(c.blue("Switch to %s..." % (v.DEFAULT_PHP))) # pylint: disable=E1101
     s.run('''ansible-playbook -i %s/orchestration/hosts\
              --user=%s %s/orchestration/commands/default-php.yml\
              --extra-vars "ansible_sudo_pass=%s"
           ''' % (v.APP_DIR, v.APP, v.APP_DIR, v.APP), shell=True)
+    return args.exit_ok

--- a/app/orchestration.py
+++ b/app/orchestration.py
@@ -90,15 +90,15 @@ def hosts_file(app):
     print(c.green("Remember to add the %s.local entry to your local /etc/hosts file!" % (app)))
 
 
-def param_check(app):
+def param_check(args):
     """Determines whether a second parameter (sitename) was passed"""
-    if not app:
+    if not args.app:
         print(c.red("This command needs a sitename to run. Aborting..."))
 
 
 def app_delete(args):
     """Deletes an arbitrary docroot"""
-    param_check(args.app)
+    param_check(args)
 
     # TODO: actually enforce arbitrary docroots through positional arguments
 
@@ -139,7 +139,7 @@ def app_drupal(args):
 
 def app_lightning(args):
     """Spins up a ready-to-use Lightning install"""
-    app_delete(args.app)
+    app_delete(args)
 
     print(c.blue("Installing Lightning into new %s docroot..." % (args.app)))
     s.run('''ansible-playbook -i %s/orchestration/hosts\
@@ -152,7 +152,7 @@ def app_lightning(args):
 
 def app_blt(args):
     """Spins up a ready-to-use BLT build"""
-    app_delete(args.app)
+    app_delete(args)
 
     print(c.blue("Installing BLT into new %s docroot..." % (args.app)))
     s.run('''ansible-playbook -i %s/orchestration/hosts\
@@ -165,7 +165,7 @@ def app_blt(args):
 
 def app_dev(args):
     """Prepares app for development work with no caching and helper modules enabled."""
-    param_check(args.app)
+    param_check(args)
 
     identify_drupal_type = s.getoutput('''grep "%s" "%s/.app-registry" |\
                                           awk '{print $NF}' | tr --d '()'

--- a/app/orchestration.py
+++ b/app/orchestration.py
@@ -119,7 +119,7 @@ def app_delete(args):
 
 def app_drupal(args):
     """Spins up a ready-to-use Drupal install"""
-    app_delete(args.app)
+    app_delete(args)
 
     # if [[ -z "${GIT_TAG}" ]]; then
     print(c.blue("Installing Drupal into new %s docroot..." % (args.app)))

--- a/app/orchestration.py
+++ b/app/orchestration.py
@@ -2,7 +2,6 @@
 """Manages orchestration for all containers"""
 
 import subprocess as s
-import sys
 import os
 import colorful as c
 import click
@@ -63,9 +62,9 @@ def run_tests_orchestration(shortname):
           ''' % (v.APP_DIR, v.APP, v.APP_DIR, shortname, v.APP), shell=True)
 
 
-def run_tests():
+def run_tests(args):
     """Runs the Ansible test suite"""
-    containers.status()
+    containers.status(args)
 
     php_version_check = s.getoutput('''docker exec -u %s -it %s /bin/cat\
                                        /etc/php/default_php_version
@@ -73,16 +72,17 @@ def run_tests():
     if v.DEFAULT_PHP not in php_version_check:
         print("Tests need to be executed against the current stable PHP version")
         print("Please switch to PHP %s with 'drucker --php%s'" % (v.DEFAULT_PHP, v.DEFAULT_PHP))
-        sys.exit()
-
+        return args.exit_fail
     for group in v.TEST_GROUPS:
         run_tests_orchestration(group)
+    return args.exit_ok
 
 
-def app_list():
+def app_list(args):
     """Returns a list of installed apps."""
     s.run('''docker exec -it %s cat %s/.app-registry
           ''' % (v.WEB_CONTAINER, v.CONTAINER_HTML_PATH), shell=True)
+    return args.exit_ok
 
 
 def hosts_file(app):
@@ -94,118 +94,135 @@ def param_check(app):
     """Determines whether a second parameter (sitename) was passed"""
     if not app:
         print(c.red("This command needs a sitename to run. Aborting..."))
-        sys.exit()
 
 
-def app_delete(app):
+def app_delete(args):
     """Deletes an arbitrary docroot"""
-    param_check(app)
+    param_check(args.app)
 
     # TODO: actually enforce arbitrary docroots through positional arguments
 
-    if os.path.isdir("%s/%s" % (v.CONTAINER_HTML_PATH, app)):
+    if os.path.isdir("%s/%s" % (v.CONTAINER_HTML_PATH, args.app)):
         if click.confirm("Should we overwrite the codebase, files and database?", default=True):
-            print(c.blue("Deleting %s docroot..." % (app)))
+            print(c.blue("Deleting %s docroot..." % (args.app)))
             s.run('''ansible-playbook -i %s/orchestration/hosts\
                      --user=%s %s/orchestration/commands/app-delete.yml\
                      --extra-vars "ansible_sudo_pass=%s app=delete sitename=%s"
-                  ''' % (v.APP_DIR, v.APP, v.APP_DIR, v.APP, app), shell=True)
-            print(c.green("Remember to remove the %s.local entry from your local /etc/hosts file!" % (app)))
+                  ''' % (v.APP_DIR, v.APP, v.APP_DIR, v.APP, args.app), shell=True)
+            print(c.green("Remember to remove the %s.local entry from your"
+                          " local /etc/hosts file!" % (args.app)))
         else:
             print(c.green("Back to the comfort zone. Aborting..."))
     else:
         print("This app doesn't exist.")
 
 
-def app_drupal(app):
+def app_drupal(args):
     """Spins up a ready-to-use Drupal install"""
-    app_delete(app)
+    app_delete(args.app)
 
     # if [[ -z "${GIT_TAG}" ]]; then
-    print(c.blue("Installing Drupal into new %s docroot..." % (app)))
+    print(c.blue("Installing Drupal into new %s docroot..." % (args.app)))
     s.run('''ansible-playbook -i %s/orchestration/hosts\
              --user=%s %s/orchestration/commands/app-drupal.yml\
              --extra-vars "ansible_sudo_pass=%s app=Drupal sitename=%s"
-          ''' % (v.APP_DIR, v.APP, v.APP_DIR, v.APP, app), shell=True)
-    hosts_file(app)
+          ''' % (v.APP_DIR, v.APP, v.APP_DIR, v.APP, args.app), shell=True)
+    hosts_file(args.app)
     # elif [[ -n "${GIT_TAG}" ]]; then
-    #     echo -e "${BLUE}Installing Drupal ${GIT_TAG} into new ${SITE} docroot...${COLOR_ENDING}"
-    #     ${COMMANDS}/app-drupal.yml --extra-vars "ansible_sudo_pass=${USER} app=Drupal sitename=${SITE} git_tag=${GIT_TAG}"
-    #     hosts_file(app)
+    #     echo -e "${BLUE}Installing Drupal ${GIT_TAG} into new
+    #         ${SITE} docroot...${COLOR_ENDING}"
+    #     ${COMMANDS}/app-drupal.yml --extra-vars "ansible_sudo_pass=${USER}
+    #         app=Drupal sitename=${SITE} git_tag=${GIT_TAG}"
+    #     hosts_file(args.app)
+    return args.exit_ok
 
 
-def app_lightning(app):
+def app_lightning(args):
     """Spins up a ready-to-use Lightning install"""
-    app_delete(app)
+    app_delete(args.app)
 
-    print(c.blue("Installing Lightning into new %s docroot..." % (app)))
+    print(c.blue("Installing Lightning into new %s docroot..." % (args.app)))
     s.run('''ansible-playbook -i %s/orchestration/hosts\
              --user=%s %s/orchestration/commands/app-lightning.yml\
              --extra-vars "ansible_sudo_pass=%s app=Lightning sitename=%s"
-          ''' % (v.APP_DIR, v.APP, v.APP_DIR, v.APP, app), shell=True)
-    hosts_file(app)
+          ''' % (v.APP_DIR, v.APP, v.APP_DIR, v.APP, args.app), shell=True)
+    hosts_file(args.app)
+    return args.exit_ok
 
 
-def app_blt(app):
+def app_blt(args):
     """Spins up a ready-to-use BLT build"""
-    app_delete(app)
+    app_delete(args.app)
 
-    print(c.blue("Installing BLT into new %s docroot..." % (app)))
+    print(c.blue("Installing BLT into new %s docroot..." % (args.app)))
     s.run('''ansible-playbook -i %s/orchestration/hosts\
              --user=%s %s/orchestration/commands/app-blt.yml\
              --extra-vars "ansible_sudo_pass=%s app=BLT sitename=%s"
-          ''' % (v.APP_DIR, v.APP, v.APP_DIR, v.APP, app), shell=True)
-    hosts_file(app)
+          ''' % (v.APP_DIR, v.APP, v.APP_DIR, v.APP, args.app), shell=True)
+    hosts_file(args.app)
+    return args.exit_ok
 
 
-def app_dev(app):
+def app_dev(args):
     """Prepares app for development work with no caching and helper modules enabled."""
-    param_check(app)
+    param_check(args.app)
 
     identify_drupal_type = s.getoutput('''grep "%s" "%s/.app-registry" |\
                                           awk '{print $NF}' | tr --d '()'
-                                       ''' % (app, v.CONTAINER_HTML_PATH))
+                                       ''' % (args.app,
+                                              v.CONTAINER_HTML_PATH))
 
     if "BLT" in identify_drupal_type:
-        print(c.red("This command is not currently compatible with BLT. Exiting..."))
-        sys.exit()
-    elif not identify_drupal_type:
+        print(c.red("This command is not currently"
+                    " compatible with BLT. Exiting..."))
+        return args.exit_fail
+    if not identify_drupal_type:
         print(c.red("Could not identify the application type. Exiting..."))
-    else:
-        print(c.blue("Configuring %s docroot for development..." % (app)))
-        s.run('''ansible-playbook -i %s/orchestration/hosts\
-                 --user=%s %s/orchestration/commands/app-dev.yml\
-                 --extra-vars "ansible_sudo_pass=%s app=dev sitename=%s"
-              ''' % (v.APP_DIR, v.APP, v.APP_DIR, v.APP, app), shell=True)
+        return args.exit_fail
+    print(c.blue("Configuring %s docroot"
+                 " for development..." % (args.app)))
+    s.run('''ansible-playbook -i %s/orchestration/hosts\
+             --user=%s %s/orchestration/commands/app-dev.yml\
+             --extra-vars "ansible_sudo_pass=%s app=dev sitename=%s"
+            ''' % (v.APP_DIR, v.APP,
+                   v.APP_DIR, v.APP, args.app), shell=True)
+    return args.exit_ok
 
 
-def app_prod(app):
+def app_prod(args):
     """Opinionated setup with all known performance best practices enabled."""
     identify_drupal_type = s.getoutput('''grep "%s" "%s/.app-registry" |\
                                           awk '{print $NF}' | tr --d '()'
-                                       ''' % (app, v.CONTAINER_HTML_PATH))
+                                       ''' % (args.app,
+                                              v.CONTAINER_HTML_PATH))
 
     if "BLT" in identify_drupal_type:
-        print(c.red("This command is not currently compatible with BLT. Exiting..."))
-        sys.exit()
-    elif not identify_drupal_type:
+        print(c.red("This command is not currently"
+                    " compatible with BLT. Exiting..."))
+        return args.exit_fail
+    if not identify_drupal_type:
         print(c.red("Could not identify the application type. Exiting..."))
-    else:
-        print(c.blue("Configuring %s docroot for production..." % (app)))
-        s.run('''ansible-playbook -i %s/orchestration/hosts\
-                 --user=%s %s/orchestration/commands/app-prod.yml\
-                 --extra-vars "ansible_sudo_pass=%s app=prod sitename=%s"
-              ''' % (v.APP_DIR, v.APP, v.APP_DIR, v.APP, app), shell=True)
+        return args.exit_fail
+    print(c.blue("Configuring %s docroot"
+                 " for production..." % (args.app)))
+    s.run('''ansible-playbook -i %s/orchestration/hosts\
+             --user=%s %s/orchestration/commands/app-prod.yml\
+             --extra-vars "ansible_sudo_pass=%s app=prod sitename=%s"
+          ''' % (v.APP_DIR, v.APP,
+                 v.APP_DIR, v.APP, args.app), shell=True)
+    return args.exit_ok
 
 
-def app_import(app):
+def app_import(args):
     """Imports an app from the web container's import directory"""
-    if not os.path.isdir("%s/%s" % (v.CONTAINER_IMPORT_PATH, app)):
-        print(c.red("The %s app doesn't exist. Aborting..." % (app)))
-        sys.exit()
-    elif os.path.isdir("%s/%s/blt" % (v.CONTAINER_IMPORT_PATH, app)):
+    import_path = v.CONTAINER_IMPORT_PATH
+    if not os.path.isdir("%s/%s" % (import_path, args.app)):
+        print(c.red("The %s app doesn't exist. Aborting..." % (args.app)))
+        return args.exit_fail
+    if os.path.isdir("%s/%s/blt" % (import_path, args.app)):
         app_detected = "BLT"
-    elif os.path.isdir("%s/%s/vendor/bin/lightning" % (v.CONTAINER_IMPORT_PATH, app)):
+    elif os.path.isdir("%s/%s/vendor/bin/lightning" % (import_path,
+                                                       args.app)):
         app_detected = "Lightning"
     else:
         app_detected = "Drupal"
@@ -213,5 +230,7 @@ def app_import(app):
     s.run('''ansible-playbook -i %s/orchestration/hosts\
              --user=%s %s/orchestration/commands/app-import.yml\
              --extra-vars "ansible_sudo_pass=%s app=%s sitename=%s"
-          ''' % (v.APP_DIR, v.APP, v.APP_DIR, v.APP, app_detected, app), shell=True)
-    hosts_file(app)
+          ''' % (v.APP_DIR, v.APP,
+                 v.APP_DIR, v.APP, app_detected, args.app), shell=True)
+    hosts_file(args.app)
+    return args.exit_ok

--- a/app/services.py
+++ b/app/services.py
@@ -17,6 +17,7 @@ def check(container, service, name):
 
 def phpfpm(container):
     """Starts PHP-FPM if it's down"""
+    assert len(container)  # Throw AssertionError if empty + silences pylint.
     if not s.getoutput('''docker exec -it %s pgrep php-fpm%s | head -1
                        ''' % (v.WEB_CONTAINER,
                               v.DEFAULT_PHP)):


### PR DESCRIPTION
**THIS CODE IS UNTESTED - TEST FIRST**

Having that said, I expect perhaps only a subtle thing, it should all work:
```
pylint app/arguments.py app/containers.py app/orchestration.py
************* Module orchestration
app/orchestration.py:103:6: W0511: TODO: actually enforce arbitrary docroots through positional arguments (fixme)

------------------------------------------------------------------
Your code has been rated at 9.95/10 (previous run: 9.95/10, +0.00)
```

See commit messages:

```
commit b1f0131a753d8d87aaa92f440a823c7257bfb907
    Since functions are objects, I'm passing them as constants into
ARGS.mainfunc. Once the command gets called, it always passes
ARGS so that it becomes available everywhere in the codebase. Each
ran command must now also state their exit status.
```
```
commit 2ab1e79c763d90268f075087fa82fe7d0edf30ca
    ARGS becomes the injected 'args' on each function, which
now all return args.exit_ok assuming they didn't fail. If commands
can still fail, over time you should return exit_fail instead.
```
```
commit e16c9e610b3fda3d623f5cfaeb4b531d623230af (HEAD -> appargs, origin/appargs)
    Same for app/orchestration.py, which I also made PEP8 compliant.
```
